### PR TITLE
fix bug: Observable.just(throwable) dont emit an error

### DIFF
--- a/app/src/main/java/com/rengwuxian/rxjavasamples/module/token_advanced_5/TokenAdvancedFragment.java
+++ b/app/src/main/java/com/rengwuxian/rxjavasamples/module/token_advanced_5/TokenAdvancedFragment.java
@@ -73,7 +73,7 @@ public class TokenAdvancedFragment extends BaseFragment {
                                                 }
                                             });
                                 }
-                                return Observable.just(throwable);
+                                return Observable.error(throwable);
                             }
                         });
                     }


### PR DESCRIPTION
Observable.just(throwable) dont emit an error, will resubscribe again.
