### PR TITLE
修复Data类中loadFromNetwork()函数如果因为网络未连接而发生错误, 不会通知界面CacheFragment进行数据更新.

### DIFF
--- a/app/src/main/java/com/rengwuxian/rxjavasamples/module/cache_6/data/Data.java
+++ b/app/src/main/java/com/rengwuxian/rxjavasamples/module/cache_6/data/Data.java
@@ -85,6 +85,7 @@ public class Data {
                     @Override
                     public void call(Throwable throwable) {
                         throwable.printStackTrace();
+	                    cache.onError(throwable);
                     }
                 });
     }
@@ -110,7 +111,14 @@ public class Data {
         } else {
             setDataSource(DATA_SOURCE_MEMORY);
         }
-        return cache.observeOn(AndroidSchedulers.mainThread()).subscribe(observer);
+        return cache
+		        .doOnError(new Action1<Throwable>() {
+			        @Override
+			        public void call(Throwable throwable) {
+						cache = null;
+			        }
+		        })
+		        .observeOn(AndroidSchedulers.mainThread()).subscribe(observer);
     }
 
     public void clearMemoryCache() {


### PR DESCRIPTION
#14
